### PR TITLE
Replaced newlines with separator character so that tciadapter obeys the |f etc. rigctld protocol.

### DIFF
--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -73,12 +73,12 @@ func (r *Response) Format() string {
 func (r *Response) ExtendedFormat(separator string) string {
 	buffer := bytes.NewBufferString("")
 
-	fmt.Fprintf(buffer, "%s:\n", r.Command)
+	fmt.Fprintf(buffer, "%s:%s", r.Command, separator)
 	for i, value := range r.Data {
 		if r.Keys[i] != "" {
-			fmt.Fprintf(buffer, "%s: %s\n", r.Keys[i], value)
+			fmt.Fprintf(buffer, "%s: %s%s", r.Keys[i], value, separator)
 		} else {
-			fmt.Fprintln(buffer, value)
+			fmt.Fprintf(buffer, "%s%s", value, separator)
 		}
 	}
 	fmt.Fprintf(buffer, "RPRT %s", r.Result)


### PR DESCRIPTION
A  TR linux user could not connect to tciadapter using rigctld. TR uses the |f, |m, etc. extended protocol.  This change fixed the problem. If this is a correct change please merge. Thank you, Kevin w9cf.